### PR TITLE
Set target to latest .NET (requires VS 2022)

### DIFF
--- a/O-Compiler/O-Compiler.csproj
+++ b/O-Compiler/O-Compiler.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>OCompiler</RootNamespace>
     <OutputPath>$(SolutionDir)\build\$(Configuration)\$(ProjectName)\bin\</OutputPath>
     <IntermediateOutputPath>$(SolutionDir)\build\$(Configuration)\$(ProjectName)\obj\</IntermediateOutputPath>


### PR DESCRIPTION
.NET 6.0 is not available in VS 2019, so you may need to upgrade to VS 2022