### PR TITLE
Fix/syntax

### DIFF
--- a/Source/OCompiler/Analyze/Syntax/Declaration/Class/Member/Field.cs
+++ b/Source/OCompiler/Analyze/Syntax/Declaration/Class/Member/Field.cs
@@ -7,10 +7,17 @@ internal class Field: Variable, IClassMember
 {
     public static bool TryParse(TokenEnumerator tokens, out Field? field)
     {
-        bool result = Variable.TryParse(tokens, out var variable);
-        field = (Field)variable!;
-        return result;
+        if (!Variable.TryParse(tokens, out var variable))
+        {
+            field = null;
+            return false;
+        }
+
+        field = new Field(variable!);
+        return true;
     }
-    
-    protected Field(Identifier name, Expression.Expression expression): base(name, expression) { }
+
+    protected Field(Identifier name, Expression.Expression expression) : base(name, expression) { }
+
+    protected Field(Variable variable) : base(variable.Identifier, variable.Expression) { }
 }

--- a/Source/OCompiler/Analyze/Syntax/Declaration/Statement/Assignment.cs
+++ b/Source/OCompiler/Analyze/Syntax/Declaration/Statement/Assignment.cs
@@ -1,28 +1,30 @@
 using System;
-using OCompiler.Analyze.Lexical.Tokens;
+using OCompiler.Analyze.Lexical.Tokens.Delimiters;
 using OCompiler.Utils;
 
 namespace OCompiler.Analyze.Syntax.Declaration.Statement;
 
 internal class Assignment : IStatement
 {
-    public Identifier Identifier { get; }
+    public Expression.Expression Variable { get; }
     
     public Expression.Expression Value { get; }
     
     public static bool TryParse(TokenEnumerator tokens, out Assignment? assignment)
     {
-        // Parse name.
-        if (tokens.Current() is not Identifier name)
+        int index = tokens.Index;
+        
+        // Variable.
+        if (!Expression.Expression.TryParse(tokens, out Expression.Expression? variable))
         {
             assignment = null;
             return false;
         }
         
         // Assign delimiter.
-        if (tokens.Next() is not Lexical.Tokens.Delimiters.Assign)
+        if (tokens.Current() is not Assign)
         {
-            tokens.Back();
+            tokens.RestoreIndex(index);
             assignment = null;
             return false;
         }
@@ -31,18 +33,18 @@ internal class Assignment : IStatement
         tokens.Next();
         
         // Expression.
-        if (!Declaration.Expression.Expression.TryParse(tokens, out Expression.Expression? expression))
+        if (!Expression.Expression.TryParse(tokens, out Expression.Expression? value))
         {
             throw new Exception($"Expected expression at position {tokens.Current().StartOffset}.");
         }
         
-        assignment = new Assignment(name, expression!);
+        assignment = new Assignment(variable!, value!);
         return true;
     }
     
-    protected Assignment(Identifier identifier, Expression.Expression value)
+    protected Assignment(Expression.Expression variable, Expression.Expression value)
     {
-        Identifier = identifier;
+        Variable = variable;
         Value = value;
     }
     
@@ -53,6 +55,6 @@ internal class Assignment : IStatement
 
     public override string ToString()
     {
-        return $"{Identifier.Literal} := {Value}";
+        return $"{Variable} := {Value}";
     }
 }

--- a/Source/OCompiler/Analyze/Syntax/Declaration/Statement/IStatement.cs
+++ b/Source/OCompiler/Analyze/Syntax/Declaration/Statement/IStatement.cs
@@ -6,12 +6,6 @@ internal interface IStatement : IBodyStatement
 {
     public static bool TryParse(TokenEnumerator tokens, out IStatement? statement)
     {
-        if (Assignment.TryParse(tokens, out Assignment? field))
-        {
-            statement = field;
-            return true;
-        }
-        
         if (If.TryParse(tokens, out If? @if))
         {
             statement = @if;
@@ -30,6 +24,12 @@ internal interface IStatement : IBodyStatement
             return true;
         }
         
+        if (Assignment.TryParse(tokens, out Assignment? field))
+        {
+            statement = field;
+            return true;
+        }
+
         statement = null;
         return false;
     }

--- a/Source/OCompiler/Analyze/Syntax/Declaration/Statement/If.cs
+++ b/Source/OCompiler/Analyze/Syntax/Declaration/Statement/If.cs
@@ -55,6 +55,9 @@ internal class If : IStatement
             throw new Exception($"Keyword 'end' expected at position {tokens.Current().StartOffset}.");
         }
 
+        // Get next token.
+        tokens.Next();
+
         @if = new If(expression!, body!, elseBody);
         return true;
     }

--- a/Source/OCompiler/Utils/TokenEnumerator.cs
+++ b/Source/OCompiler/Utils/TokenEnumerator.cs
@@ -5,6 +5,7 @@ namespace OCompiler.Utils;
 
 internal class TokenEnumerator
 {
+    public int Index { get; private set; }
     private readonly BufferedEnumerator<Token> _tokens;
     
     public TokenEnumerator(IEnumerable<Token> tokens)
@@ -15,7 +16,12 @@ internal class TokenEnumerator
     public Token Next(bool skipWhitespaces = true)
     {
         // Skip whitespaces.
-        while (_tokens.MoveNext() && skipWhitespaces && _tokens.Current is Whitespace) { }
+        while (_tokens.MoveNext() && skipWhitespaces && _tokens.Current is Whitespace)
+        {
+            Index += 1;
+        }
+
+        Index += 1;
         
         return _tokens.Current;
     }
@@ -31,8 +37,33 @@ internal class TokenEnumerator
     public Token Back(bool skipWhitespaces = true)
     {
         // Skip whitespaces.
-        while (_tokens.MoveBack() && skipWhitespaces && _tokens.Current is Whitespace) { }
+        while (_tokens.MoveBack() && skipWhitespaces && _tokens.Current is Whitespace)
+        {
+            Index -= 1;
+        }
+        
+        Index -= 1;
         
         return _tokens.Current;
+    }
+
+    public void RestoreIndex(int index)
+    {
+        // Back.
+        if (Index > index)
+        {
+            while (Index != index)
+            {
+                Back();
+            }
+            
+            return;
+        }
+        
+        // Next.
+        while (Index != index)
+        {
+            Next();
+        }
     }
 }


### PR DESCRIPTION
Fix syntax analyzer to work properly with `if`, `:=` and field definitions