### PR TITLE
Add build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,29 @@ A compiler for the O language is made for educational purposes.
 
 ## How to build and run programs
 
-Soon:tm:
+The target platform of the project is `.NET 6`. It is required to have it installed.
+
+### How to compile a compiler
+
+1. Open the `.sln` file in Visual Studio or Rider.
+2. Click `Build Solution` or `Build Project`.
+
+### How to run programs in The O language
+
+*Note: currently The O language programs can only be interpreted because `.NET 6` does not allow to save binary files. We will be working on this issue soon.*
+
+> To get familiar with the language, read more about the language documentation (links are in the bottom).
+
+To run the O language program, you should save it to a file with `.ol` format.
+Then, run the compiler with the following command:
+
+```
+dotnet OCompiler <module_name> <class_name> [parameters]
+```
+
+1. `module_name` is a path to your `.ol` file.
+2. `class_name` is a name of class whose constructor will be an entry point of the program.
+3. `parameters` is a space-separated list of parameters for the class constructor (they can only be of a primitive built-in type).
 
 ## Additional information
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,17 @@ The target platform of the project is `.NET 6`. It is required to have it instal
 1. Open the `.sln` file in Visual Studio or Rider.
 2. Click `Build Solution` or `Build Project`.
 
-### How to run programs in The O language
+### How to run programs from Visual Studio / Rider
+
+You can do either of the following:
+- Create a new launch setting based on existing ones.
+- Edit any program in `Examples` folder.
+
+After that, select the desired launch configuration and press `Launch`. Your IDE should automagically build a compiler for you, and then run the program.
+
+Also, be sure to read through the next section.
+
+### How to run programs from the command line
 
 *Note: currently The O language programs can only be interpreted because `.NET 6` does not allow to save binary files. We will be working on this issue soon.*
 


### PR DESCRIPTION
This PR adds instructions on how to build the compiler, as well as build and run the O lang programs.

The section about compiler build can probably be improved, but personally I've got no idea how to do that with hands from CLI :trollface: 