### PR TITLE
Smol fixes

### DIFF
--- a/Examples/chain-calls.ol
+++ b/Examples/chain-calls.ol
@@ -1,5 +1,5 @@
 class Main is
-  this is IO().Write("give me one integer pls") end 
+  this() is IO().Write("give me one integer pls") end 
   this(a: Integer) is
     IO().WriteLine(Calculator().magic(a).ToString())
   end

--- a/Examples/fibonacci.ol
+++ b/Examples/fibonacci.ol
@@ -20,7 +20,7 @@ class Main is
             this.fib(this.pred(this.pred(num)))
         )
     end
-    this is
+    this() is
         IO().Write("You need to pass an Integer as an argument")
     end
     this(N: Integer) is

--- a/Examples/generics.ol
+++ b/Examples/generics.ol
@@ -1,5 +1,5 @@
 class Main is
-    this is
+    this() is
         var list: List<Dictionary<String, Pair<Integer, String>>> = []
         list.Append({})
         var pair = Pair(42, "Amogus")

--- a/Examples/inheritance-simple.ol
+++ b/Examples/inheritance-simple.ol
@@ -1,5 +1,5 @@
 class Main is
-	this is
+	this() is
 		var somePhone = NotMyPhone()
 		somePhone.Turn_on()
 	end
@@ -19,14 +19,14 @@ class Phone is
 end
 
 class IPhone extends Phone is
-	this is
+	this() is
 		// basic serial number for all iPhones
 		this.serial = 700000000
 	end
 end
 
 class NotMyPhone extends IPhone is
-	this is
+	this() is
 		this.serial = this.serial.Plus(123456)
 	end
 end

--- a/Examples/inheritance.ol
+++ b/Examples/inheritance.ol
@@ -1,5 +1,5 @@
 class Main is
-    this is
+    this() is
         var cat = SuperCat("James", "LaserEyes")
         
         IO().WriteLine(cat.Fight())

--- a/Examples/lists_and_dicts.ol
+++ b/Examples/lists_and_dicts.ol
@@ -36,7 +36,7 @@ class Main is
     IO().Write("}")
   end
 
-  this is
+  this() is
     var lst: List<Integer> = [1, 2, 3]
     PrintList(lst)
     var reversed_list = ReverseList(lst)

--- a/Examples/strings.ol
+++ b/Examples/strings.ol
@@ -4,7 +4,7 @@
   (both multiline and single-line)
 */
 class Main is
-  this is
+  this() is
     // Create a string and take some symbols
     var hello = "hello\" world"
     IO().Write(hello)

--- a/Examples/sum-of-two.ol
+++ b/Examples/sum-of-two.ol
@@ -1,5 +1,5 @@
 class Main is
-  this is
+  this() is
     IO().WriteLine("Please, input 2 integers as parameters")
   end
 

--- a/Examples/tic-tac-toe.ol
+++ b/Examples/tic-tac-toe.ol
@@ -4,11 +4,11 @@ class Random is
     var Mod = 9343
     var value = 0
     
-    this is 
+    this() is 
         this.value = Time().Current().Mod(this.Mod)
     end
     
-    this (seed: Integer) is 
+    this(seed: Integer) is 
         this.value = seed.Mod(this.Mod)
     end
     
@@ -39,7 +39,7 @@ class TicTacToe is
     var level = 0
     var random = Random()
     
-    this is
+    this() is
         this.PrintGuideline()
         
         // Ask hard level.

--- a/Examples/type_annotations.ol
+++ b/Examples/type_annotations.ol
@@ -1,5 +1,5 @@
 class Main is
-    this is
+    this() is
         // Explicit type annotation
         var list1: List<Integer> = []
         list1.Append(20)

--- a/Examples/wrong_comment.ol
+++ b/Examples/wrong_comment.ol
@@ -3,10 +3,10 @@
   (both multiline and single-line)
 *
 class Main is
-  this is
-    // Create a string and modify some symbols
+  this() is
+    // Create a string and print some symbols
     var hello = "hello world"
-    hello.At(0, "H")
-    hello.At(5, "_")
+    IO().WriteLine(hello.At(0))
+    IO().WriteLine(hello.At(5))
   end
 end

--- a/Examples/wrong_string.ol
+++ b/Examples/wrong_string.ol
@@ -3,10 +3,10 @@
   (both multiline and single-line)
 */
 class Main is
-  this is
-    // Create a string and modify some symbols
+  this() is
+    // Create a string and print some symbols
     var hello = "hello\" world
-    hello.At(0, "H")
-    hello.At(5, "_")
+    IO().WriteLine(hello.At(0))
+    IO().WriteLine(hello.At(5))
   end
 end

--- a/Source/OCompiler/Analyze/Semantics/ParsedFieldInfo.cs
+++ b/Source/OCompiler/Analyze/Semantics/ParsedFieldInfo.cs
@@ -1,5 +1,6 @@
 ﻿using OCompiler.Analyze.Semantics.Expression;
 using OCompiler.Analyze.Syntax.Declaration.Class.Member;
+using OCompiler.Exceptions;
 
 namespace OCompiler.Analyze.Semantics;
 
@@ -13,6 +14,13 @@ internal class ParsedFieldInfo
 
     public ParsedFieldInfo(Field parsedField, Context context)
     {
+        if (parsedField.Expression is null)
+        {
+            throw new CompilerInternalError(
+                $"Field {parsedField.Identifier.Literal} is not assigned. This is not supported in the current version of the compiler."
+            );
+        }
+
         Context = context;
         Field = parsedField;
         Expression = new ExpressionInfo(parsedField.Expression, Context);

--- a/Source/OCompiler/Analyze/Semantics/TreeValidator.cs
+++ b/Source/OCompiler/Analyze/Semantics/TreeValidator.cs
@@ -141,6 +141,13 @@ internal class TreeValidator
             varInfo = new ExpressionInfo(variable.Expression, new Context(classInfo, callable));
             callable.LocalVariables.Add(variableName, varInfo);
         }
+
+        if (variable.Expression is null)
+        {
+            throw new CompilerInternalError(
+                $"Variable {variable.Identifier.Literal} is not assigned. This is not supported in the current version of the compiler."
+            );
+        }
         varInfo.ValidateExpression();
     }
 

--- a/Source/OCompiler/Analyze/Syntax/Declaration/Class/Member/Method/Parameters.cs
+++ b/Source/OCompiler/Analyze/Syntax/Declaration/Class/Member/Method/Parameters.cs
@@ -14,7 +14,7 @@ internal static class Parameters
         var parameters = new List<Parameter>();
         if (tokens.Current() is not Lexical.Tokens.Delimiters.LeftParenthesis)
         {
-            return parameters;
+            throw new SyntaxError(tokens.Current().Position, "Expected parameters or ()");
         }
         
         // Get next token.

--- a/Source/OCompiler/Builtins/Compound/Dict.cs
+++ b/Source/OCompiler/Builtins/Compound/Dict.cs
@@ -1,13 +1,14 @@
-﻿using OCompiler.Builtins.Primitives;
+﻿using System.Collections.Generic;
 
-using System.Collections.Generic;
-using System.Linq;
+using OCompiler.Builtins.Primitives;
 
 namespace OCompiler.Builtins.Compound;
 
 public class Dict<K, V> : Class where K : notnull
 {
-    private readonly Dictionary<K, V> _dictionary = new();
+    private readonly Dictionary<K, V> _dictionary;
+
+    public Dict() => _dictionary = new();
 
     public Dict(IEnumerable<KeyValuePair<K, V>> items) => _dictionary = new(items);
 

--- a/Source/OCompiler/Builtins/Compound/List.cs
+++ b/Source/OCompiler/Builtins/Compound/List.cs
@@ -20,7 +20,12 @@ public class List<T> : Class
 
     public void RemoveAt(Integer index) => _list.RemoveAt(index.Value);
     
-    public void Pop() => _list.RemoveAt(_list.Count - 1);
+    public T Pop() {
+        var lastIndex = _list.Count - 1;
+        var item = _list[lastIndex];
+        _list.RemoveAt(lastIndex);
+        return item;
+    }
     
     public Integer Search(T item) => new(_list.IndexOf(item));
 }

--- a/Source/OCompiler/Builtins/Compound/List.cs
+++ b/Source/OCompiler/Builtins/Compound/List.cs
@@ -1,12 +1,14 @@
-﻿using OCompiler.Builtins.Primitives;
+﻿using System.Collections.Generic;
 
-using System.Collections.Generic;
+using OCompiler.Builtins.Primitives;
 
 namespace OCompiler.Builtins.Compound;
 
 public class List<T> : Class
 {
     private readonly System.Collections.Generic.List<T> _list = new();
+
+    public List() => _list = new();
 
     public List(IEnumerable<T> items) => _list = new(items);
 

--- a/Source/OCompiler/Builtins/Primitive/Integer.cs
+++ b/Source/OCompiler/Builtins/Primitive/Integer.cs
@@ -109,6 +109,11 @@ public class Integer : Class
         return new Integer(Value % p.Value);
     }
 
+    public Real Mod(Real p)
+    {
+        return new Real(Value % p.Value);
+    }
+
 
     public Boolean Less(Integer p)
     {

--- a/Source/OCompiler/Builtins/Primitive/Real.cs
+++ b/Source/OCompiler/Builtins/Primitive/Real.cs
@@ -51,8 +51,14 @@ public class Real : Class
     {
         return new String(Value.ToString(CultureInfo.CurrentCulture));
     }
-    
-    
+
+
+    public Real UnaryMinus()
+    {
+        return new Real(-Value);
+    }
+
+
     public Real Plus(Integer p)
     {
         return new Real(Value + p.Value);
@@ -95,14 +101,19 @@ public class Real : Class
     {
         return new Real(Value / p.Value);
     }
-    
-    
+
+
     public Real Mod(Integer p)
     {
         return new Real(Value % p.Value);
     }
-    
-    
+
+    public Real Mod(Real p)
+    {
+        return new Real(Value % p.Value);
+    }
+
+
     public Boolean Less(Integer p)
     {
         return new Boolean(Value < p.Value);


### PR DESCRIPTION
- enforce `()` on methods if no parameters (no more `this is end`, finally)
- make `var` have an *optional* assignment, if the type is specified
  - these should default to no-param constructor of that type then (e.g. `var s: String` is auto-assigned `String()`)
- fix numeric methods
- `List` and `Dict` fixes